### PR TITLE
Fix reading `boneCountMax` out of bounds.

### DIFF
--- a/M2Loader.js
+++ b/M2Loader.js
@@ -2405,6 +2405,7 @@ class M2SkinLoader extends Loader {
 		const submeshesOffset = parser.readUInt32();
 		const batchesLength = parser.readUInt32();
 		const batchesOffset = parser.readUInt32();
+		const boneCountMax = parser.readUInt32();
 
 		// local vertex list
 
@@ -2469,10 +2470,6 @@ class M2SkinLoader extends Loader {
 			batches.push( batch );
 
 		}
-
-		//
-
-		const boneCountMax = parser.readUInt32();
 
 		// TODO read shadow batches
 


### PR DESCRIPTION
So I noticed the airelemental.m2 from WotLK (3.3.5a, not classic) is different from the I got from https://wow.tools (the WotLK-version actually has MORE geometry). But the skin for the WotLK-Version could not be loaded, since the parser was reading out-of-bounds because the offset was incorrect at that point. This is fixed by reading `boneCountMax` together with the header instead of after the content.