### PR TITLE
Simplify `listGlobalSequences` to `hasGlobalSequences`.

### DIFF
--- a/M2Loader.js
+++ b/M2Loader.js
@@ -3008,21 +3008,9 @@ class SequenceManager {
 
 	}
 
-	listGlobalSequences() {
+	hasGlobalSequences() {
 
-		const list = [];
-
-		for ( let i = 0; i < this.globalSequences.length; i ++ ) {
-
-			list.push( {
-				id: i
-			} );
-
-		}
-
-		list.sort( sortId );
-
-		return list;
+		return this.globalSequences.length > 0;
 
 	}
 

--- a/test/index.html
+++ b/test/index.html
@@ -120,7 +120,6 @@
 					// the list() methods provide arrays with all available sequences (animations)
 
 					const sequences = m2SequenceManager.listSequences();
-					const globalSequences = m2SequenceManager.listGlobalSequences();
 
 					animationFolder = gui.addFolder( 'Animations' );
 
@@ -144,11 +143,11 @@
 
 					}
 
-					if ( globalSequences.length > 0 ) {
+					if ( m2SequenceManager.hasGlobalSequences() ) {
 
 						m2SequenceManager.playGlobalSequences();
 			
-						animationFolder.add( params, 'playGlobalSequences' ).onChange( onGlobalSequenceChange );
+						animationFolder.add( params, 'playGlobalSequences' ).onChange( onPlayGlobalSequencesChange );
 			
 					}
 
@@ -220,7 +219,7 @@
 
 			}
 
-			function onGlobalSequenceChange( value ) {
+			function onPlayGlobalSequencesChange( value ) {
 
 				if ( value === true ) {
 


### PR DESCRIPTION
- since global sequences are now played all together and can't be played individually, listing them is not very useful, so I replaced `listGlobalSequences` with `hasGlobalSequences` to check whether global sequences are present
- renamed `onGlobalSequenceChange` to `onPlayGlobalSequencesChange` to reflect the new variable-name

Previously this PR hat more changes, but it was decided to split them into two PRs:
- now you can select different variations for sequences from the drop-down
- renamed `params.sequences` to `params.sequence` since it refers to a single sequence and not multiple ones