### PR TITLE
Change type to module

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
     "eslint-config-mdcs": "^5.0.0",
     "eslint-plugin-html": "^7.1.0",
     "serve": "^14.2.1"
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
If threejs is being used on a website with a bundler this option needs to be specified since the package uses import statements